### PR TITLE
Add Google Sign-In support

### DIFF
--- a/prisma/migrations/20240203203238_delete_logged_with_google/migration.sql
+++ b/prisma/migrations/20240203203238_delete_logged_with_google/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `loggedWithGoogle` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "loggedWithGoogle";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,45 +1,44 @@
 generator client {
-  provider = "prisma-client-js"
+    provider = "prisma-client-js"
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
 }
 
 model Project {
-  id          String       @id @db.Uuid @default(uuid())
-  title       String       @unique(map: "projectTitle_unique") @db.VarChar(80)
-  link        String       @db.VarChar(200)
-  description String
-  imagePath   String       @db.VarChar(200)
-  userId      String       @db.Uuid
-  releaseDate DateTime     @db.Date
-  User        User         @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId_FK")
-  ProjectTag  ProjectTag[]
+    id          String       @id @default(uuid()) @db.Uuid
+    title       String       @unique(map: "projectTitle_unique") @db.VarChar(80)
+    link        String       @db.VarChar(200)
+    description String
+    imagePath   String       @db.VarChar(200)
+    userId      String       @db.Uuid
+    releaseDate DateTime     @db.Date
+    User        User         @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId_FK")
+    ProjectTag  ProjectTag[]
 }
 
 model ProjectTag {
-  id        String  @id @db.Uuid @default(uuid())
-  projectId String  @db.Uuid
-  tagId     String  @db.Uuid
-  Project   Project @relation(fields: [projectId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "projectId_FK")
-  Tag       Tag     @relation(fields: [tagId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "tagId_FK")
+    id        String  @id @default(uuid()) @db.Uuid
+    projectId String  @db.Uuid
+    tagId     String  @db.Uuid
+    Project   Project @relation(fields: [projectId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "projectId_FK")
+    Tag       Tag     @relation(fields: [tagId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "tagId_FK")
 }
 
 model Tag {
-  id         String       @id @db.Uuid @default(uuid())
-  name       String       @unique(map: "name_unique") @db.VarChar(30)
-  ProjectTag ProjectTag[]
+    id         String       @id @default(uuid()) @db.Uuid
+    name       String       @unique(map: "name_unique") @db.VarChar(30)
+    ProjectTag ProjectTag[]
 }
 
 model User {
-  id               String    @id @db.Uuid @default(uuid())
-  name             String    @db.VarChar(30)
-  lastName         String    @db.VarChar(70)
-  email            String    @unique(map: "email_unique") @db.VarChar(80)
-  password   String?   @db.VarChar(200)
-  googleId         String?   @unique(map: "googleId_unique") @db.VarChar(200)
-  loggedWithGoogle Boolean?  @default(false)
-  Project          Project[]
+    id       String    @id @default(uuid()) @db.Uuid
+    name     String    @db.VarChar(30)
+    lastName String    @db.VarChar(70)
+    email    String    @unique(map: "email_unique") @db.VarChar(80)
+    password String?   @db.VarChar(200)
+    googleId String?   @unique(map: "googleId_unique") @db.VarChar(200)
+    Project  Project[]
 }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -12,3 +12,9 @@ export async function signIn(req: Request, res: Response) {
 
     res.status(200).send({ token: token });
 }
+
+export async function signInWithGoogle(req: Request, res: Response) {
+    const token = await userService.signInWithGoogle(res.locals.verified);
+
+    res.status(200).send({ token: token });
+}

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -1,7 +1,7 @@
 import prisma from '../config/database';
 import { User } from '@prisma/client';
 
-export async function createUser(newUser: SignUpData) {
+export async function createUser(newUser: SignUpData | SignInWithGoogleData) {
     return prisma.user.create({
         data: newUser,
     });
@@ -13,6 +13,10 @@ export async function findUserByEmail(email: string) {
     });
 }
 
-export interface SignUpData extends Omit<User, 'id'> {}
+export interface SignUpData
+    extends Omit<User, 'id' | 'googleId' | 'loggedWithGoogle'> {}
 
 export interface SignInData extends Pick<User, 'email' | 'password'> {}
+
+export interface SignInWithGoogleData
+    extends Omit<User, 'id' | 'password' | 'loggedWithGoogle'> {}

--- a/src/routers/userRouter.ts
+++ b/src/routers/userRouter.ts
@@ -1,6 +1,10 @@
 import { Router } from 'express';
 import validateSchema from '../middlewares/validateSchemaMiddleware';
-import { signInSchema, signUpSchema } from '../schemas/signSchemas';
+import {
+    googleSignInSchema,
+    signInSchema,
+    signUpSchema,
+} from '../schemas/signSchemas';
 import * as userController from '../controllers/userController';
 
 const userRouter = Router();
@@ -8,5 +12,11 @@ const userRouter = Router();
 userRouter.post('/signup', validateSchema(signUpSchema), userController.signUp);
 
 userRouter.post('/signin', validateSchema(signInSchema), userController.signIn);
+
+userRouter.post(
+    '/signin/google',
+    validateSchema(googleSignInSchema),
+    userController.signInWithGoogle,
+);
 
 export default userRouter;

--- a/src/schemas/signSchemas.ts
+++ b/src/schemas/signSchemas.ts
@@ -1,16 +1,25 @@
 import joi from 'joi';
-import { SignUpData, SignInData } from '../repositories/userRepository';
+import {
+    SignUpData,
+    SignInData,
+    SignInWithGoogleData,
+} from '../repositories/userRepository';
 
 export const signUpSchema = joi.object<SignUpData>({
     email: joi.string().email().required(),
     password: joi.string().min(6).required(),
     name: joi.string().required(),
     lastName: joi.string().required(),
-    googleId: joi.string().allow(null),
-    loggedWithGoogle: joi.boolean().required(),
 });
 
 export const signInSchema = joi.object<SignInData>({
     email: joi.string().email().required(),
     password: joi.string().required(),
+});
+
+export const googleSignInSchema = joi.object<SignInWithGoogleData>({
+    email: joi.string().email().required(),
+    googleId: joi.string().required(),
+    name: joi.string().required(),
+    lastName: joi.string().required(),
 });

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,5 +1,9 @@
 import * as userRepository from '../repositories/userRepository';
-import { SignInData, SignUpData } from '../repositories/userRepository';
+import {
+    SignInData,
+    SignUpData,
+    SignInWithGoogleData,
+} from '../repositories/userRepository';
 import * as errorUtils from '../utils/errorUtils';
 import { comparePassword, hashPassword } from '../utils/passwordUtils';
 import { createToken } from '../utils/tokenUtils';
@@ -34,6 +38,15 @@ export async function signIn(userCredentials: SignInData) {
     if (!isPasswordValid) {
         throw errorUtils.unauthorizedError('Invalid user information');
     }
+
+    return createToken(user.id);
+}
+
+export async function signInWithGoogle(googleUser: SignInWithGoogleData) {
+    const { email } = googleUser;
+
+    const user = await userRepository.findUserByEmail(email);
+    if (!user) return await userRepository.createUser(googleUser);
 
     return createToken(user.id);
 }


### PR DESCRIPTION
This commit introduces the ability for users to sign in via their Google accounts. A new route, '/signin/google', has been added to handle Google sign-ins. This is accompanied by the necessary functions and schema updates in the user service, controller, repositories and prisma schema. It also includes the removal of the 'loggedWithGoogle' column from the 'User' table.