### PR TITLE
Disable ESLint rule for unused vars in errorMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Orange API
+
+## Descrição
+
+A Orange API é uma aplicação backend desenvolvida para gerenciar operações de um sistema. Esta aplicação foi construída
+utilizando TypeScript, SQL e JavaScript, e gerenciada pelo npm.
+
+## Tecnologias Utilizadas
+
+- **TypeScript**: Linguagem de programação utilizada para desenvolver a aplicação.
+- **SQL**: Linguagem de consulta estruturada utilizada para gerenciar os dados armazenados no banco de dados.
+- **JavaScript**: Linguagem de programação utilizada para adicionar funcionalidades dinâmicas à aplicação.
+- **npm**: Gerenciador de pacotes utilizado para instalar e gerenciar pacotes de software.
+
+## Dependências
+
+A aplicação possui várias dependências, que são listadas no arquivo `package.json`. Algumas das principais dependências
+incluem:
+
+- **express**: Framework para Node.js que simplifica o desenvolvimento de aplicações web.
+- **bcrypt**: Biblioteca utilizada para hash de senhas.
+- **jsonwebtoken**: Biblioteca utilizada para criar e verificar tokens JWT.
+- **multer**: Middleware para manipulação de multipart/form-data, usado principalmente para upload de arquivos.
+- **prisma**: ORM para TypeScript e JavaScript para gerenciar o banco de dados.
+- **supabase-js**: Biblioteca para interagir com o Supabase, uma alternativa de código aberto ao Firebase.
+
+## Como Utilizar
+
+Para utilizar a aplicação, você precisa ter o Node.js e o npm instalados em seu sistema. Após clonar o repositório, você
+pode instalar as dependências da aplicação executando `npm install` no diretório raiz do projeto.
+
+Os scripts disponíveis para execução estão listados no arquivo `package.json` e podem ser executados
+com `npm run <nome_do_script>`. Por exemplo, para iniciar a aplicação, você pode executar `npm run start`.
+
+## Endpoints
+
+A aplicação possui vários endpoints que permitem interagir com o sistema. A documentação completa para cada endpoint
+será fornecida em breve.

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,19 +2,21 @@ import { Request, Response } from 'express';
 import * as userService from '../services/userService';
 
 export async function signUp(req: Request, res: Response) {
-    await userService.signUp(res.locals.verified);
+    const newUser = await userService.signUp(res.locals.verified);
 
-    res.sendStatus(201);
+    if (!newUser) return res.sendStatus(500);
+
+    return res.sendStatus(201);
 }
 
 export async function signIn(req: Request, res: Response) {
     const token = await userService.signIn(res.locals.verified);
 
-    res.status(200).send({ token: token });
+    return res.status(200).send({ token: token });
 }
 
 export async function signInWithGoogle(req: Request, res: Response) {
     const token = await userService.signInWithGoogle(res.locals.verified);
 
-    res.status(200).send({ token: token });
+    return res.status(200).send({ token: token });
 }

--- a/src/middlewares/errorMiddleware.ts
+++ b/src/middlewares/errorMiddleware.ts
@@ -9,9 +9,11 @@ export default function errorMiddleware(
     err: Error | AppError,
     req: Request,
     res: Response,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     next: NextFunction,
 ) {
     if (isAppError(err)) {
+        console.error(err.message);
         return res.status(errorTypeToStatusCode(err.type)).send(err.message);
     }
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -13,10 +13,8 @@ export async function findUserByEmail(email: string) {
     });
 }
 
-export interface SignUpData
-    extends Omit<User, 'id' | 'googleId' | 'loggedWithGoogle'> {}
+export interface SignUpData extends Omit<User, 'id' | 'googleId'> {}
 
 export interface SignInData extends Pick<User, 'email' | 'password'> {}
 
-export interface SignInWithGoogleData
-    extends Omit<User, 'id' | 'password' | 'loggedWithGoogle'> {}
+export interface SignInWithGoogleData extends Omit<User, 'id' | 'password'> {}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -39,7 +39,9 @@ export async function signIn(userCredentials: SignInData) {
         throw errorUtils.unauthorizedError('Invalid user information');
     }
 
-    return createToken(user.id);
+    const userId = user.id;
+
+    return createToken(userId);
 }
 
 export async function signInWithGoogle(googleUser: SignInWithGoogleData) {
@@ -48,5 +50,7 @@ export async function signInWithGoogle(googleUser: SignInWithGoogleData) {
     const user = await userRepository.findUserByEmail(email);
     if (!user) return await userRepository.createUser(googleUser);
 
-    return createToken(user.id);
+    const userId = user.id;
+
+    return createToken(userId);
 }

--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -8,7 +8,7 @@ if (!process.env.JWT_SECRET) {
 }
 
 export function createToken(userId: string) {
-    return jwt.sign({ userId: userId }, process.env.JWT_SECRET!, {
+    return jwt.sign({ userId }, process.env.JWT_SECRET!, {
         expiresIn: process.env.JWT_EXPIRES_IN,
     });
 }


### PR DESCRIPTION
The ESLint rule for unused variables was disabled in errorMiddleware.ts to avoid unnecessary warnings. Additionally, this commit includes improvements in userController's response handling and enhanced logging for errors. Minor adjustments were also made in the SignUpData and SignInWithGoogleData interfaces for consistency.