### PR TITLE
Improve project service and update database schema

### DIFF
--- a/prisma/migrations/20240204222429_image_url/migration.sql
+++ b/prisma/migrations/20240204222429_image_url/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `imageUrl` to the `Project` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Project" ADD COLUMN     "imageUrl" VARCHAR(200) NOT NULL;

--- a/prisma/migrations/20240204224405_cascade_project_delete/migration.sql
+++ b/prisma/migrations/20240204224405_cascade_project_delete/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "ProjectTag" DROP CONSTRAINT "projectId_FK";
+
+-- AddForeignKey
+ALTER TABLE "ProjectTag" ADD CONSTRAINT "projectId_FK" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,7 @@ model Project {
     link        String       @db.VarChar(200)
     description String
     imagePath   String       @db.VarChar(200)
+    imageUrl    String       @db.VarChar(200)
     userId      String       @db.Uuid
     releaseDate DateTime     @db.Date
     User        User         @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "userId_FK")
@@ -23,7 +24,7 @@ model ProjectTag {
     id        String  @id @default(uuid()) @db.Uuid
     projectId String  @db.Uuid
     tagId     String  @db.Uuid
-    Project   Project @relation(fields: [projectId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "projectId_FK")
+    Project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: Cascade, map: "projectId_FK")
     Tag       Tag     @relation(fields: [tagId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "tagId_FK")
 }
 

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -33,11 +33,11 @@ export async function getProjectsByUserId(req: Request, res: Response) {
     const { userId } = req.params;
     const projects = await projectService.getProjectsByUserId(userId);
 
-    return res.sendStatus(201).json(projects);
+    return res.sendStatus(200).json(projects);
 }
 
 export async function getProjects(req: Request, res: Response) {
     const projects = await projectService.getProjects();
 
-    return res.sendStatus(201).json(projects);
+    return res.sendStatus(200).json(projects);
 }

--- a/src/repositories/tagRepository.ts
+++ b/src/repositories/tagRepository.ts
@@ -25,25 +25,6 @@ export async function associateTagWithProject(
     });
 }
 
-export async function deleteProjectTags(projectId: string): Promise<void> {
-    await prisma.projectTag.deleteMany({
-        where: { projectId: projectId },
-    });
-}
-
-export async function getTagsByProjectId(projectId: string): Promise<Tag[]> {
-    const projectTags = await prisma.projectTag.findMany({
-        where: { projectId: projectId },
-    });
-    const tags = await Promise.all(
-        projectTags.map(projectTag => {
-            const findUniqueQuery = { where: { id: projectTag.tagId } };
-            return prisma.tag.findUnique(findUniqueQuery);
-        }),
-    );
-    return tags.filter(tag => tag !== null) as Tag[];
-}
-
 export async function getProjectTags(projectId: string): Promise<ProjectTag[]> {
     return await prisma.projectTag.findMany({
         where: { projectId: projectId },

--- a/src/routers/projectRouter.ts
+++ b/src/routers/projectRouter.ts
@@ -21,7 +21,7 @@ projectRouter.delete(
     projectController.deleteProject,
 );
 
-projectRouter.put(
+projectRouter.patch(
     '/updateProject/:projectId',
     tokenMiddleware,
     validateSchema(updateProjectDataSchema),


### PR DESCRIPTION
Unused console log statements have been removed from the project service for cleaner and more efficient code. The database schema has been updated to include 'imageUrl' in the 'Project' table and a relationship constraint to delete tags linked to a project when the project is deleted has been added. The method of updating projects in the router has been changed from PUT to PATCH. The status codes for the 'getProjects' and 'getProjectsByUserId' routes have been corrected from 201 to 200.