### PR TITLE
Refactor project retrieval methods and enhance error handling

### DIFF
--- a/src/repositories/projectRepository.ts
+++ b/src/repositories/projectRepository.ts
@@ -40,7 +40,7 @@ export async function getProjectById(projectId: string) {
         where: { id: projectId },
         include: {
             ProjectTag: {
-                include: {
+                select: {
                     Tag: {
                         select: {
                             id: true,
@@ -52,31 +52,6 @@ export async function getProjectById(projectId: string) {
         },
     });
 }
-
-// export async function getProjectById(projectId: string) {
-//     return prisma.project.findUnique({
-//         where: { id: projectId },
-//         select: {
-//             id: true,
-//             title: true,
-//             description: true,
-//             imagePath: true,
-//             userId: true,
-//             link: true,
-//             releaseDate: true,
-//             ProjectTag: {
-//                 select: {
-//                     Tag: {
-//                         select: {
-//                             id: true,
-//                             name: true,
-//                         },
-//                     },
-//                 },
-//             },
-//         },
-//     });
-// }
 
 export async function getProjectsByUserId(userId: string) {
     return prisma.project.findMany({
@@ -85,7 +60,7 @@ export async function getProjectsByUserId(userId: string) {
         },
         include: {
             ProjectTag: {
-                include: {
+                select: {
                     Tag: {
                         select: {
                             id: true,
@@ -98,41 +73,21 @@ export async function getProjectsByUserId(userId: string) {
     });
 }
 
-// export async function getProjectsByUserId(
-//     userId: string,
-//     limit: number,
-//     offset: number,
-// ) {
-//     return prisma.project.findMany({
-//         where: {
-//             userId: userId,
-//         },
-//         select: {
-//             id: true,
-//             title: true,
-//             description: true,
-//             imagePath: true,
-//             userId: true,
-//             link: true,
-//             releaseDate: true,
-//             ProjectTag: {
-//                 select: {
-//                     Tag: {
-//                         select: {
-//                             id: true,
-//                             name: true,
-//                         },
-//                     },
-//                 },
-//             },
-//         },
-//         take: limit,
-//         skip: offset,
-//     });
-// }
-
 export async function getProjects() {
-    return prisma.project.findMany();
+    return prisma.project.findMany({
+        include: {
+            ProjectTag: {
+                select: {
+                    Tag: {
+                        select: {
+                            id: true,
+                            name: true,
+                        },
+                    },
+                },
+            },
+        },
+    });
 }
 
 export interface newProjectDataSchemaInterface

--- a/src/services/projectService.ts
+++ b/src/services/projectService.ts
@@ -92,11 +92,10 @@ export async function updateProject(
 }
 
 export async function getProjectById(projectId: string) {
-    const foundProject = await projectRepository.getProjectById(projectId);
+    const projectInfo = await projectRepository.getProjectById(projectId);
+    if (!projectInfo) throw errorUtils.notFoundError('Project not found');
 
-    if (!foundProject) throw errorUtils.notFoundError('Project not found');
-
-    const { ProjectTag, ...projectData } = foundProject;
+    const { ProjectTag, ...projectData } = projectInfo;
     const project = {
         ...projectData,
         tags: ProjectTag.map(projectTag => projectTag.Tag),
@@ -106,12 +105,11 @@ export async function getProjectById(projectId: string) {
 }
 
 export async function getProjectsByUserId(userId: string) {
-    const foundProjects = await projectRepository.getProjectsByUserId(userId);
-
-    if (!foundProjects) throw errorUtils.notFoundError('Projects not found');
+    const projectList = await projectRepository.getProjectsByUserId(userId);
+    if (!projectList) throw errorUtils.notFoundError('Projects not found');
 
     const projects = [];
-    for (const project of foundProjects) {
+    for (const project of projectList) {
         const { ProjectTag, ...projectData } = project;
         const projectWithTags = {
             ...projectData,
@@ -124,5 +122,18 @@ export async function getProjectsByUserId(userId: string) {
 }
 
 export async function getProjects() {
-    return projectRepository.getProjects();
+    const projectList = await projectRepository.getProjects();
+    if (!projectList) throw errorUtils.notFoundError('Projects not found');
+
+    const projects = [];
+    for (const project of projectList) {
+        const { ProjectTag, ...projectData } = project;
+        const projectWithTags = {
+            ...projectData,
+            tags: ProjectTag.map(projectTag => projectTag.Tag),
+        };
+        projects.push(projectWithTags);
+    }
+
+    return projects;
 }


### PR DESCRIPTION
Refactored methods 'getProjectById', 'getProjectsByUserId', and 'getProjects' in the project services and repositories to improve clarity and readability. Improved error handling to throw 'not found' error when no projects are returned. Additionally, unused code sections were removed for tidier and cleaner code.